### PR TITLE
bumping npm module braces to version 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3671,9 +3671,9 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -10968,7 +10968,7 @@
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {


### PR DESCRIPTION
Uncontrolled resource consumption in braces

- Bumped node module braces from 3.0.2 -> 3.0.3

[PSREDEV-1104 ](https://govukverify.atlassian.net/browse/PSREDEV-1104)
## Checklist

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
**_Comment:_**

### Co-authored by